### PR TITLE
fix: improve error handling for bad requests and invalid JSON inputs

### DIFF
--- a/routers-ktor/src/commonMain/kotlin/dev/kaccelero/routers/TemplateChildModelRouter.kt
+++ b/routers-ktor/src/commonMain/kotlin/dev/kaccelero/routers/TemplateChildModelRouter.kt
@@ -44,7 +44,7 @@ open class TemplateChildModelRouter<Model : IChildModel<Id, CreatePayload, Updat
 ) {
 
     open suspend fun handleExceptionTemplate(
-        exception: Exception,
+        exception: Throwable,
         call: ApplicationCall,
         fromTemplate: String,
     ) {

--- a/routers-ktor/src/jvmTest/kotlin/dev/kaccelero/routers/APIModelRouterTest.kt
+++ b/routers-ktor/src/jvmTest/kotlin/dev/kaccelero/routers/APIModelRouterTest.kt
@@ -295,6 +295,24 @@ class APIModelRouterTest {
     }
 
     @Test
+    fun testAPIPostRouteInvalidJson() = testApplication {
+        val client = installApp(this)
+        val router = createRouter(mockk())
+        routing {
+            router.createRoutes(this)
+        }
+        val response = client.post("/api/testmodels") {
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertEquals(
+            mapOf("error" to "Illegal input: Field 'string' is required for type with serial name 'dev.kaccelero.mocks.TestCreatePayload', but it was missing at path: \$"),
+            response.body()
+        )
+    }
+
+    @Test
     fun testAPIPostRouteOpenAPI() = testApplication {
         val client = installApp(this)
         val controller = mockk<ITestModelController>()


### PR DESCRIPTION
Fixes #5 

Now, when a JSON decoding error happens, it returns a body like this:

```json
{
    "error": "Illegal input: Field 'string' is required for type with serial name 'dev.kaccelero.mocks.TestCreatePayload', but it was missing at path: $"
}
```