### PR TITLE
feat: propagate request id (api + amqp)

### DIFF
--- a/messaging-amqp/build.gradle.kts
+++ b/messaging-amqp/build.gradle.kts
@@ -74,6 +74,7 @@ kotlin {
             dependencies {
                 api(project(":core"))
                 api(libs.amqp)
+                api(libs.ktor.utils.callid)
             }
         }
         val jvmTest by getting {

--- a/messaging-amqp/src/commonMain/kotlin/dev/kaccelero/commons/messaging/Extensions.kt
+++ b/messaging-amqp/src/commonMain/kotlin/dev/kaccelero/commons/messaging/Extensions.kt
@@ -1,5 +1,10 @@
 package dev.kaccelero.commons.messaging
 
+import dev.kourier.amqp.AMQPResponse
+import dev.kourier.amqp.Field
+import io.ktor.callid.*
+import io.ktor.http.*
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 
 /**
@@ -28,4 +33,31 @@ suspend inline fun <reified T> tryWithAttempts(
             delay(delay) // Try again after delay
         }
     }
+}
+
+/**
+ * Retrieves the current request ID from the coroutine context, if available.
+ *
+ * @return A map containing the request ID header, or an empty map if not available.
+ */
+suspend fun mapOfRequestId(): Map<String, Field.LongString> {
+    return currentCoroutineContext()[KtorCallIdContextElement]
+        ?.let { mapOf(HttpHeaders.XRequestId to Field.LongString(it.callId)) }
+        ?: emptyMap()
+}
+
+/**
+ * Executes a block of code with a specified call ID in the coroutine context, if the call ID is present.
+ *
+ * @param delivery The AMQP message delivery containing the call ID in headers.
+ * @param block The block of code to execute.
+ */
+suspend fun withCallId(delivery: AMQPResponse.Channel.Message.Delivery, block: suspend () -> Unit) {
+    val callId = delivery.message.properties.headers?.get(HttpHeaders.XRequestId)?.let {
+        when (it) {
+            is Field.LongString -> it.value
+            else -> null
+        }
+    }
+    callId?.let { withCallId(it, block) } ?: block()
 }

--- a/routers-client-ktor/src/commonMain/kotlin/dev/kaccelero/client/IAPIClient.kt
+++ b/routers-client-ktor/src/commonMain/kotlin/dev/kaccelero/client/IAPIClient.kt
@@ -7,13 +7,41 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 
+/**
+ * API client interface defining the contract for making HTTP requests.
+ */
 interface IAPIClient {
 
+    /**
+     * Base URL of the API.
+     */
     val baseUrl: String
+
+    /**
+     * Use case to get the current token, if applicable.
+     */
     val getTokenUseCase: IGetTokenUseCase?
+
+    /**
+     * Use case to renew the token, if applicable.
+     */
     val renewTokenUseCase: IRenewTokenUseCase?
+
+    /**
+     * Use case to log out, if applicable.
+     */
     val logoutUseCase: ILogoutUseCase?
 
+    /**
+     * Makes an HTTP request to the specified path with the given method and request builder.
+     * It also applies token management if the relevant use cases are provided.
+     *
+     * @param method The HTTP method to use (e.g., GET, POST).
+     * @param path The API endpoint path.
+     * @param builder A lambda to configure the HTTP request.
+     *
+     * @return The HTTP response.
+     */
     suspend fun request(
         method: HttpMethod,
         path: String,

--- a/routers-client-ktor/src/jvmTest/kotlin/dev/kaccelero/client/AbstractAPIClientTest.kt
+++ b/routers-client-ktor/src/jvmTest/kotlin/dev/kaccelero/client/AbstractAPIClientTest.kt
@@ -1,0 +1,57 @@
+package dev.kaccelero.client
+
+import dev.kaccelero.models.UUID
+import io.ktor.callid.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AbstractAPIClientTest {
+
+    @Test
+    fun testRequestContainsNoRequestIdIfNotSpecified() = runBlocking {
+        val client = object : AbstractAPIClient(
+            "https://example.com",
+            engine = MockEngine { request ->
+                assertEquals(null, request.headers[HttpHeaders.XRequestId])
+                respond("OK", HttpStatusCode.OK)
+            }
+        ) {}
+        client.request(HttpMethod.Get, "/test")
+        Unit
+    }
+
+    @Test
+    fun testRequestContainsNoRequestIdIfNotEnabled() = runBlocking {
+        val client = object : AbstractAPIClient(
+            "https://example.com",
+            engine = MockEngine { request ->
+                assertEquals(null, request.headers[HttpHeaders.XRequestId])
+                respond("OK", HttpStatusCode.OK)
+            }
+        ) {
+            override fun shouldPropagateRequestId(method: HttpMethod, path: String): Boolean = false
+        }
+        withCallId(UUID().toString()) {
+            client.request(HttpMethod.Get, "/test")
+        }
+    }
+
+    @Test
+    fun testRequestContainsOriginalRequestId() = runBlocking {
+        val requestId = UUID().toString()
+        val client = object : AbstractAPIClient(
+            "https://example.com",
+            engine = MockEngine { request ->
+                assertEquals(requestId, request.headers[HttpHeaders.XRequestId])
+                respond("OK", HttpStatusCode.OK)
+            }
+        ) {}
+        withCallId(requestId) {
+            client.request(HttpMethod.Get, "/test")
+        }
+    }
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -72,6 +72,7 @@ dependencyResolutionManagement {
             library("ktor-client-content-negotiation", "io.ktor", "ktor-client-content-negotiation").versionRef("ktor")
             library("ktor-client-auth", "io.ktor", "ktor-client-auth").versionRef("ktor")
             library("ktor-client-mock", "io.ktor", "ktor-client-mock").versionRef("ktor")
+            library("ktor-utils-callid", "io.ktor", "ktor-call-id").versionRef("ktor")
 
             bundle(
                 "ktor-server-api",
@@ -105,7 +106,8 @@ dependencyResolutionManagement {
                     "ktor-client-core",
                     "ktor-client-content-negotiation",
                     "ktor-serialization-kotlinx-json",
-                    "ktor-client-auth"
+                    "ktor-client-auth",
+                    "ktor-utils-callid"
                 )
             )
             bundle(


### PR DESCRIPTION
Fixes #26 

Ktor already sets the request id in a coroutine context when installing the Call ID plugin:
```kotlin
install(CallId) {
    header(HttpHeaders.XRequestId)
    generate { "some-prefix-${UUID()}" }
}
```

So here we capture it and propagate it in the api and amqp clients.